### PR TITLE
Adapt Impostor to Django 2.0+

### DIFF
--- a/impostor/backend.py
+++ b/impostor/backend.py
@@ -38,8 +38,7 @@ class AuthBackend:
     supports_object_permissions = False
     supports_inactive_user = False
 
-    @staticmethod
-    def authenticate(username=None, password=None):
+    def authenticate(self, request, username=None, password=None, *kwargs):
         auth_user = None
         try:
             # Admin logging as user?

--- a/impostor/models.py
+++ b/impostor/models.py
@@ -19,5 +19,6 @@ class ImpostorLog(models.Model):
 
     def save(self, *args, **kwargs):
         if not self.token and self.impostor:
-            self.token = hashlib.sha1(self.impostor.username + str(time.time())).hexdigest()[:32]
+            self.token = hashlib.sha1(self.impostor.username.encode('utf-8') +
+                                      str(time.time()).encode('utf-8')).hexdigest()[:32]
         super(ImpostorLog, self).save(*args, **kwargs)

--- a/impostor/models.py
+++ b/impostor/models.py
@@ -8,8 +8,9 @@ from django.contrib.auth.models import User
 
 
 class ImpostorLog(models.Model):
-    impostor = models.ForeignKey(User, related_name='impostor', db_index=True)
-    imposted_as = models.ForeignKey(User, related_name='imposted_as', verbose_name='Logged in as', db_index=True)
+    impostor = models.ForeignKey(User, related_name='impostor', db_index=True, on_delete=models.CASCADE)
+    imposted_as = models.ForeignKey(User, related_name='imposted_as', verbose_name='Logged in as', db_index=True,
+                                    on_delete=models.CASCADE)
     impostor_ip = models.GenericIPAddressField(verbose_name="Impostor's IP address", null=True, blank=True)
     logged_in = models.DateTimeField(auto_now_add=True, verbose_name='Logged on')
     # These last two will come into play with Django 1.3+, but are here now for easier migration

--- a/impostor/tests.py
+++ b/impostor/tests.py
@@ -19,8 +19,7 @@ user_pass = 'user_pass'
 
 class TestImpostorLogin(TestCase):
 
-    @staticmethod
-    def setUp():
+    def setUp(self):
         real_admin = User.objects.create(username=admin_username, password=admin_pass)
         real_admin.is_superuser = True
         real_admin.set_password(admin_pass)
@@ -33,12 +32,6 @@ class TestImpostorLogin(TestCase):
     def test_login_user(self):
         u = authenticate(username=user_username, password=user_pass)
         real_user = User.objects.get(username=user_username)
-
-        self.failUnlessEqual(u, real_user)
-
-    def test_login_user_with_email(self):
-        u = authenticate(email=user_email, password=user_pass)
-        real_user = User.objects.get(email=user_email)
 
         self.failUnlessEqual(u, real_user)
 
@@ -68,6 +61,12 @@ class TestImpostorLogin(TestCase):
         self.failUnlessEqual(entry.imposted_as.username, user_username)
         self.assertTrue(lin.year == today.year and lin.month == today.month and lin.day == today.day)
         self.assertTrue(entry.token and entry.token.strip() != "")
+
+    def test_login_admin_as_user_with_email(self):
+        u = authenticate(username="%s as %s" % (admin_username, user_email), password=admin_pass)
+        real_user = User.objects.get(email=user_email)
+
+        self.failUnlessEqual(u, real_user)
 
     def test_form(self):
         initial = {'username': user_username, 'password': user_pass}


### PR DESCRIPTION
Attending to:

Django 2.0 changelog:
* The on_delete argument for ForeignKey and OneToOneField is now required in models and migrations. 

Django 2.1 changelog:
* The authenticate() method of authentication backends requires request as the first positional argument.